### PR TITLE
Add missing page css

### DIFF
--- a/Resources/Private/Partials/Form/Page.html
+++ b/Resources/Private/Partials/Form/Page.html
@@ -3,6 +3,7 @@
     <f:format.raw>
         <f:format.json value="{
             title: page.title,
+            css: page.css,
             pageId: page.uid,
             fields: '{f:render(partial: \'Form/Fields\', arguments: \'{_all}\') -> headless:format.json.decode()}'
         }"/>


### PR DESCRIPTION
Page css is missing in page object. It's needed to get e.g. 'nolabel' info.