### PR TITLE
FIX: InvalidArgumentForHashGenerationException

### DIFF
--- a/Classes/ViewHelpers/Form/RegisterFieldViewHelper.php
+++ b/Classes/ViewHelpers/Form/RegisterFieldViewHelper.php
@@ -20,43 +20,9 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Exception;
  */
 class RegisterFieldViewHelper extends AbstractFormFieldViewHelper
 {
-    public function initializeArguments(): void
-    {
-        $this->registerArgument('name', 'string', 'Name of input tag');
-        $this->registerArgument('value', 'mixed', 'Value of input tag');
-        $this->registerArgument(
-            'property',
-            'string',
-            'Name of Object Property. If used in conjunction with <f:form object="...">, "name" and "value" properties will be ignored.'
-        );
-        $this->registerArgument('additionalAttributes', 'array', 'Additional tag attributes. They will be added directly to the resulting HTML tag.', false);
-        $this->registerArgument('checked', 'bool', 'Specifies that the input element should be preselected');
-        $this->registerArgument('multiple', 'bool', 'Specifies whether this checkbox belongs to a multivalue (is part of a checkbox group)', false, false);
-    }
-
     public function render(): string
     {
         $nameAttribute = $this->getName();
-
-        $checked = $this->arguments['checked'];
-        $multiple = $this->arguments['multiple'];
-
-        $propertyValue = null;
-        if ($this->hasMappingErrorOccurred()) {
-            $propertyValue = $this->getLastSubmittedFormData();
-        }
-        if ($checked === null && $propertyValue === null) {
-            $propertyValue = $this->getPropertyValue();
-        }
-
-        if ($propertyValue instanceof \Traversable) {
-            $propertyValue = iterator_to_array($propertyValue);
-        }
-        if (is_array($propertyValue)) {
-            $nameAttribute .= '[]';
-        } elseif ($multiple === true) {
-            $nameAttribute .= '[]';
-        }
 
         $this->registerFieldNameForFormTokenGeneration($nameAttribute);
 

--- a/Resources/Private/Partials/Form/Field/Check.html
+++ b/Resources/Private/Partials/Form/Field/Check.html
@@ -1,8 +1,6 @@
 {namespace vh=In2code\Powermail\ViewHelpers}
 <f:spaceless>
-    <headlesspowermail:form.registerField property="{field.marker}."
-                            value="{setting.value}"
-                            checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:iteration.cycle)}"/>
+    <headlesspowermail:form.registerField property="{field.marker}." />
         <f:format.raw>
             <f:format.json value="{
                 field: {

--- a/Resources/Private/Partials/Form/Field/Country.html
+++ b/Resources/Private/Partials/Form/Field/Country.html
@@ -1,9 +1,7 @@
 {namespace vh=In2code\Powermail\ViewHelpers}
 <f:spaceless>
     <f:variable name="fieldMarker" value="{field.marker}{f:if(condition:field.multiselect,then:'.')}" />
-    <headlesspowermail:form.registerField property="{fieldMarker}"
-                            value="{setting.value}"
-                            checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:index.cycle)}"/>
+    <headlesspowermail:form.registerField property="{fieldMarker}" />
     <f:format.raw>
         <f:format.json value="{
                 field: {

--- a/Resources/Private/Partials/Form/Field/Radio.html
+++ b/Resources/Private/Partials/Form/Field/Radio.html
@@ -1,8 +1,6 @@
 {namespace vh=In2code\Powermail\ViewHelpers}
 <f:spaceless>
-    <headlesspowermail:form.registerField property="{field.marker}."
-                            value="{setting.value}"
-                            checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:iteration.cycle)}"/>
+    <headlesspowermail:form.registerField property="{field.marker}." />
     <f:format.raw>
         <f:format.json value="{
                 field: {

--- a/Resources/Private/Partials/Form/Field/Select.html
+++ b/Resources/Private/Partials/Form/Field/Select.html
@@ -1,9 +1,7 @@
 {namespace vh=In2code\Powermail\ViewHelpers}
 <f:spaceless>
     <f:variable name="fieldMarker" value="{field.marker}{f:if(condition:field.multiselect,then:'.')}" />
-    <headlesspowermail:form.registerField property="{fieldMarker}"
-                            value="{setting.value}"
-                            checked="{vh:misc.prefillMultiField(field:field, mail:mail, cycle:iteration.cycle)}"/>
+    <headlesspowermail:form.registerField property="{fieldMarker}" />
     <f:format.raw>
         <f:format.json value="{
                 field: {


### PR DESCRIPTION
This error occurs on failed serverside validations: The form field "tx_powermail_pi1[field][mycheckboxes][][]" is invalid. Reason: "[]" used not as last argument, but somewhere in the middle (like foo[][bar]).

Related: #34